### PR TITLE
Migrated include call for EJS 3.x

### DIFF
--- a/unit_2/lesson_10/finish/express_templates/package.json
+++ b/unit_2/lesson_10/finish/express_templates/package.json
@@ -9,7 +9,7 @@
   "author": "Jon Wexler",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.6.1",
+    "ejs": "^3.1.2",
     "express": "^4.16.3",
     "express-ejs-layouts": "^2.5.0"
   }

--- a/unit_2/lesson_10/finish/express_templates/views/layout.ejs
+++ b/unit_2/lesson_10/finish/express_templates/views/layout.ejs
@@ -42,7 +42,7 @@
 
 <body>
 
-	<% include partials/navigation %>
+	<%- include('partials/navigation') %>
 	<div id="container">
 		<%- body %>
 	</div>


### PR DESCRIPTION
Changed the call for includes in the template for the 3.x build of EJS that prevented the template from rendering. Otherwise, Node throws a _SyntaxError: Unexpected identifier in layout.ejs while compiling ejs_ error. Great book! 